### PR TITLE
Fixed a crash when reducing VR Window

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Bash needs lf even on windows/cygwin
+*.st eol=lf
+*.sh eol=lf
+
+# st files are always text, even if they contain invalid encoded chars
+*.st text diff
+
+# GitHub is unable to properly detect Smalltalk code, so help it a bit
+*.st linguist-language=Smalltalk

--- a/tonel/WodenSceneGraph-OSWindow/WDAbstractRenderingSceneStateOSWindow.class.st
+++ b/tonel/WodenSceneGraph-OSWindow/WDAbstractRenderingSceneStateOSWindow.class.st
@@ -82,8 +82,19 @@ WDAbstractRenderingSceneStateOSWindow >> defaultExtent [
 
 { #category : #'as yet unclassified' }
 WDAbstractRenderingSceneStateOSWindow >> displayExtent [
-	swapChain ifNotNil: [ ^ swapChain getWidth @ swapChain getHeight ].
-	^ extent
+	| width height |
+	
+	swapChain ifNotNil: [ 
+		width := swapChain getWidth.
+		height := swapChain getHeight.
+	].
+
+	(height isNil or:[height = 0]) ifTrue:[
+		width := extent x.
+		height := extent y. 
+	].
+
+	^ width @ height
 ]
 
 { #category : #'initialize-release' }


### PR DESCRIPTION
When opening a Woden app through "openInVR" and reducing the window, the application crashed.

This was because of the way the method "displayExtent" was coded, which led to a division by zero.